### PR TITLE
Fixed contents for "Controlling load balancing policies"

### DIFF
--- a/load-balancing/step2.md
+++ b/load-balancing/step2.md
@@ -6,22 +6,22 @@ Open envoy configuration file `envoy/envoy.yaml`{{open}}
 
 Add to envoy's configuration the definition of `load_assignment`
 <pre class="file" data-filename="envoy.yaml" data-target="append">
-load_assignment:
-  cluster_name: targetCluster
-  endpoints:
-  - lb_endpoints:
-    - endpoint:
-        address:
-          socket_address:
-            address: 172.18.0.3
-            port_value: 80
-    load_balancing_weight: 90
-  - lb_endpoints:
-    - endpoint:
-        address:
-          socket_address:
-            address: 172.18.0.4
-            port_value: 80
+    load_assignment:
+      cluster_name: targetCluster
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 172.18.0.3
+                port_value: 80
+        load_balancing_weight: 90
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 172.18.0.4
+                port_value: 80
 </pre>
 
 


### PR DESCRIPTION
Hi, thank you for good contents 👍

- https://www.katacoda.com/envoyproxy/scenarios/load-balancing

# What

I found that `step2.md` has wrong instructions.

Because `load_assignment` yaml snippet has injected at wrong position like this.

<img width="1702" alt="wrong_envoy_yaml" src="https://user-images.githubusercontent.com/1573290/71672050-35ea4780-2db8-11ea-82c4-26894912d4b8.png">

# 1. Wrong new line ⚠️ Please help

I don't know how I fix it.
Attached `.yaml` files in this repo are good.

- https://github.com/envoyproxy/katacoda-scenarios/blob/master/load-balancing/assets/envoy.yaml
- https://github.com/envoyproxy/katacoda-scenarios/blob/master/load-balancing/assets/envoy-completed.yaml

Can you fix it ?

# 2. Missing indent

I fixed it.
Add more indents.

Thanks.