### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/api-based-dynamic-routing-configuration/assets/eds_server/main.py
+++ b/api-based-dynamic-routing-configuration/assets/eds_server/main.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
   
 from flask import Flask, request, abort
 from flask_restplus import Api, Resource, fields, marshal
@@ -77,7 +78,7 @@ class Servicesv2(Resource):
     def post(self):
         '''Get hosts for service v2'''
         data = json.loads(request.data)
-        print " Inbound v2 request for discovery.  POST payload: " + str(data)
+        print(" Inbound v2 request for discovery.  POST payload: " + str(data))
         resp = ''
         try:
           id = data['node']["id"]
@@ -136,7 +137,7 @@ class Servicesv1(Resource):
     @api.marshal_with(services)    
     def get(self, service_name):
         '''Get hosts for service v1'''
-        print " Inbound v2 request for discovery.  GET service_name: " + service_name        
+        print(" Inbound v2 request for discovery.  GET service_name: " + service_name)        
         try:
           return DAO.services[service_name]        
         except KeyError: 

--- a/api-based-dynamic-routing-configuration/assets/upstream/server.py
+++ b/api-based-dynamic-routing-configuration/assets/upstream/server.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 
 from flask import Flask, request, abort
 
@@ -11,14 +12,14 @@ uid = uuid.uuid4()
 
 @app.route('/')
 def index():
-    print request.headers
-    print "--------------"
+    print(request.headers)
+    print("--------------")
     return str(uid)
 
 @app.route('/healthz')
 def health():
-    print request.headers
-    print "/healthz"
+    print(request.headers)
+    print("/healthz")
     return "ok"
 
 import sys, getopt
@@ -29,7 +30,7 @@ def main(argv):
    try:
       opts, args = getopt.getopt(argv,"p:",["port="])
    except getopt.GetoptError:
-      print 'server.py -p <portnumber>'
+      print('server.py -p <portnumber>')
       sys.exit(2)
    for opt, arg in opts:
       if opt in ("-p", "--port"):


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.