### PR TITLE
Update links to the latest docs

### DIFF
--- a/migrating-from-nginx-to-envoy/step4.md
+++ b/migrating-from-nginx-to-envoy/step4.md
@@ -39,6 +39,6 @@ For the static configuration, the filters define how to handle incoming requests
           - name: envoy.router
 </pre>
 
-The name *envoy.http_connection_manager* is a built-in filter within Envoy Proxy. Other filters include _Redis_, _Mongo_, _TCP_. You can find the complete list in the [documentation](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/listener/listener.proto#envoy-api-file-envoy-api-v2-listener-listener-proto).
+The name *envoy.http_connection_manager* is a built-in filter within Envoy Proxy. Other filters include _Redis_, _Mongo_, _TCP_. You can find the complete list in the [documentation](https://www.envoyproxy.io/docs/envoy/latest/api-v3/listeners/listeners).
 
-For more information about other load balancing policies visit the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/v1.8.0/intro/arch_overview/load_balancing).
+For more information about other load balancing policies visit the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/arch_overview).


### PR DESCRIPTION
https://www.envoyproxy.io/try/migrating-from-nginx-to-envoy

In step 4 docs point to the broken links.